### PR TITLE
Add IPackedAuto to documentation

### DIFF
--- a/guides/networking-custom-classes-structs-and-types.md
+++ b/guides/networking-custom-classes-structs-and-types.md
@@ -6,6 +6,18 @@ Networking custom classes and structs can be extremely useful to send over the n
 
 {% embed url="https://youtu.be/Ck13MQuYBV0?si=AUuMKixhUCXphEkK" %}
 
+### IPackedAuto
+This will allow PurrNet to automatically handle the serialization for you. This is useful for [Broadcasting](..\systems-and-modules\broadcast.md), as data outside of a [Network Behaviour](..\systems-and-modules\broadcast.md) may have trouble serializing over the network.\
+An example of using this is below:
+
+```csharp
+public struct ManagedStruct : IPackedAuto
+{
+    public int myInt;
+    public object data;
+}
+```
+
 ### IPackedSimple
 
 This allows you to handle the serialization yourself. This is the easiest way if you need to make your own serializer.\


### PR DESCRIPTION
Add `IPackedAuto` to the docs, as passing structs over a broadcast on a non `NetworkBehaviour` will have serialization errors.

Open to feedback on this one as I am not 100p sure my wording is correct