### PR TITLE
Broadcast Chat Guide formatting / grammar

### DIFF
--- a/guides/broadcast-chat-system.md
+++ b/guides/broadcast-chat-system.md
@@ -5,8 +5,8 @@ description: >-
 
 # Chat System with Broadcasting
 
-## 0. The Idea
-Broadcsting in PurrNet is useful, as it allows us to do some basic network functionality, all without needing a `NetworkBehaviour` on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a `NetworkBehaviour`.
+## Introduction
+Broadcasting in PurrNet is useful, as it allows us to do some basic network functionality without needing a `NetworkBehaviour` on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a `NetworkBehaviour`.
 
 The idea is as follows:
 1. Create a `ChatMessage` struct to store data such as a `name` and `message`.
@@ -14,8 +14,8 @@ The idea is as follows:
 3. Receive `ChatMessage` on the **Server**, then broadcast the `ChatMessage` to all **Clients**.
 4. Receive `ChatMessage` on the **Clients**, then print the `ChatMessage` out.
 
-## 1. Creating the `ChatMessage` struct:
-To get our chat message to the server, we need to first create a struct to hold our data. As previously mentioned, this struct will hold a `name`, and a `message`. This struct will need to implement the `IPackedAuto` interface, which will automatically handle the reading and writing of the data to the network. If this is not your style, take a look at the `IPacked` and `IPackedSimple` interfaces.
+## Creating the `ChatMessage` struct:
+To get our chat message to the **Server**, we need to first create a struct to hold our data. As previously mentioned, this struct will hold a `name`, and a `message`. This struct will need to implement the [IPackedAuto](..\guides\networking-custom-classes-structs-and-types.md#IPackedAuto) interface, which will automatically handle the reading and writing of the data to the network. If this is not your style, take a look at the [IPacked](..\guides\networking-custom-classes-structs-and-types.md#IPacked) and [IPackedSimple](..\guides\networking-custom-classes-structs-and-types.md#IPackedSimple) interfaces.
 
 The final struct is as follows:
 ```csharp
@@ -26,7 +26,7 @@ public struct ChatMessage : IPackedAuto
 }
 ```
 
-## 2. Sending a `ChatMessage` to the **Server**
+## Sending a `ChatMessage` to the **Server**
 For our **Clients** to be able to send a message to the **Server**, we first need to hook into the `Subscribe` event from the `NetworkManager`
 ```csharp
 void NetworkManager.Subscribe<ChatMessage>(PlayerBroadcastDelegate<ChatMessage> callback, bool asServer)
@@ -43,13 +43,13 @@ For our case, let's create a `ChatManager` script, that inherits from `PurrMonoB
 ```csharp
 public class ChatManager : PurrMonoBehaviour
 {
-    // Subscribe to ChatMessage events as either the server, client, or both
+    // Subscribe to ChatMessage events as either the Server, Client, or both
     public override void Subscribe(NetworkManager manager, bool asServer)
     {
         manager.Subscribe<ChatMessage>(OnChatMessage, asServer);
     }
 
-    // Unsubscribe to ChatMessage events as either the server, client, or both
+    // Unsubscribe to ChatMessage events as either the Server, Client, or both
     public override void Unsubscribe(NetworkManager manager, bool asServer)
     {
         manager.Unsubscribe<ChatMessage>(OnChatMessage, asServer);
@@ -63,7 +63,7 @@ public class ChatManager : PurrMonoBehaviour
 }
 ```
 
-Now that we've subscribed to the events required, we can actually send a `ChatMessage` to the server! You can do this however you'd like, for testing, something like this will be more than sufficient for our needs: 
+Now that we've subscribed to the events required, we can actually send a `ChatMessage` to the **Server**! You can do this however you'd like, for testing, something like this will be more than sufficient for our needs: 
 
 ```csharp
 void Update()
@@ -81,14 +81,14 @@ void Update()
 }
 ```
 
-## 3. Receiving a `ChatMessage` on the server, and sending it to all **Clients**
-Now that we are sending messages from the **Client**, lets sketch our `OnChatMessage` function out to handle receiving a `ChatMessage` broadcast on the server. As mentioned, if we are the server receiving the broadcast, we want to relay this information and broadcast it back to all of our clients, and we can do it very simply with `NetworkManager.SendToAll<ChatMessage>(ChatMessage)`:
+## Receiving a `ChatMessage` on the **Server**, and sending it to all **Clients**
+Now that we are sending messages from the **Client**, let's update our `OnChatMessage` function to handle receiving a `ChatMessage` broadcast on the **Server**. As mentioned, if we are the **Server** receiving the broadcast, we want to relay this information and broadcast it back to all of our **Clients**, and we can do it very simply with `NetworkManager.SendToAll<ChatMessage>(ChatMessage)`:
 
 ```csharp
 // Called when a ChatMessage broadcast is sent from either the Server or a Client
 private void OnChatMessage(PlayerID player, ChatMessage data, bool asServer)
 {
-    if (asServer)   // The broadcast was sent to the server from a client
+    if (asServer)   // The broadcast was sent to the Server from a Client
     {
         // Send the broadcast down to the Clients
         InstanceHandler.NetworkManager.SendToAll<ChatMessage>(data);
@@ -96,26 +96,26 @@ private void OnChatMessage(PlayerID player, ChatMessage data, bool asServer)
 }
 ```
 
-## 4. Receiving a `ChatMessage` on the Client
-Now that we are receiving messages from the **Server**, we can use our same `OnChatMessage` function to handle the data from the server. For now, let's just debug the message:
+## Receiving a `ChatMessage` on the **Client**
+Now that we are receiving messages from the **Server**, we can use our same `OnChatMessage` function to handle the data from the **Server**. For now, let's just debug the message:
 
 ```csharp
 // Called when a ChatMessage broadcast is sent from either the Server or a Client
 private void OnChatMessage(PlayerID player, ChatMessage data, bool asServer)
 {
-    if (asServer)   // The broadcast was sent to the server from a client
+    if (asServer)   // The broadcast was sent to the Server from a Client
     {
         // Send the broadcast down to the Clients
         InstanceHandler.NetworkManager.SendToAll<ChatMessage>(data);
     }
-    else    // The broadcast was send to the clients from the server
+    else    // The broadcast was sent to the Clients from the Server
     {
         Debug.Log($"Received {data.message} from {data.name}!");
     }
 }
 ```
 
-## 5. Wrap Up
+## Wrap Up
 With what we have, our final script should look like such:
 
 ```csharp
@@ -141,13 +141,13 @@ public class ChatManager : PurrMonoBehaviour
         }
     }
 
-    // Subscribe to ChatMessage events as either the server, client, or both
+    // Subscribe to ChatMessage events as either the Server, Client, or both
     public override void Subscribe(NetworkManager manager, bool asServer)
     {
         manager.Subscribe<ChatMessage>(OnChatMessage, asServer);
     }
 
-    // Unsubscribe to ChatMessage events as either the server, client, or both
+    // Unsubscribe to ChatMessage events as either the Server, Client, or both
     public override void Unsubscribe(NetworkManager manager, bool asServer)
     {
         manager.Unsubscribe<ChatMessage>(OnChatMessage, asServer);
@@ -156,12 +156,12 @@ public class ChatManager : PurrMonoBehaviour
     // Called when a ChatMessage broadcast is sent from either the Server or a Client
     private void OnChatMessage(PlayerID player, ChatMessage data, bool asServer)
     {
-        if (asServer)   // The broadcast was sent to the server from a client
+        if (asServer)   // The broadcast was sent to the Server from a Client
         {
             // Send the broadcast down to the Clients
             InstanceHandler.NetworkManager.SendToAll<ChatMessage>(data);
         }
-        else    // The broadcast was send to the clients from the server
+        else    // The broadcast was sent to the Clients from the Server
         {
             Debug.Log($"Received {data.message} from {data.name}!");
         }

--- a/guides/broadcast-chat-system.md
+++ b/guides/broadcast-chat-system.md
@@ -6,7 +6,7 @@ description: >-
 # Chat System with Broadcasting
 
 ## Introduction
-Broadcasting in PurrNet is useful, as it allows us to do some basic network functionality without needing a `NetworkBehaviour` on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a `NetworkBehaviour`.
+Broadcasting in PurrNet is useful, as it allows us to do some basic network functionality without needing a [Network Behaviour](..\systems-and-modules\network-identity\networkbehaviour.md) on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a [Network Behaviour](..\systems-and-modules\network-identity\networkbehaviour.md).
 
 The idea is as follows:
 1. Create a `ChatMessage` struct to store data such as a `name` and `message`.


### PR DESCRIPTION
Formats `guides/broadcast-chat-system.md` to be closer to the language used throughout the docs, as well as fixing multiple spelling and clarity issues.

Open to feedback!