### PR TITLE
Use forward slash isntead of backslash in docs

### DIFF
--- a/guides/broadcast-chat-system.md
+++ b/guides/broadcast-chat-system.md
@@ -6,7 +6,7 @@ description: >-
 # Chat System with Broadcasting
 
 ## Introduction
-Broadcasting in PurrNet is useful, as it allows us to do some basic network functionality without needing a [Network Behaviour](..\systems-and-modules\network-identity\networkbehaviour.md) on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a [Network Behaviour](..\systems-and-modules\network-identity\networkbehaviour.md).
+Broadcasting in PurrNet is useful, as it allows us to do some basic network functionality without needing a [Network Behaviour](../systems-and-modules/network-identity/networkbehaviour.md) on our object. For things that are trivial, such as game chat, we don't necessarily need all the functionality of a [Network Behaviour](../systems-and-modules/network-identity/networkbehaviour.md).
 
 The idea is as follows:
 1. Create a `ChatMessage` struct to store data such as a `name` and `message`.
@@ -15,7 +15,7 @@ The idea is as follows:
 4. Receive `ChatMessage` on the **Clients**, then print the `ChatMessage` out.
 
 ## Creating the `ChatMessage` struct:
-To get our chat message to the **Server**, we need to first create a struct to hold our data. As previously mentioned, this struct will hold a `name`, and a `message`. This struct will need to implement the [IPackedAuto](..\guides\networking-custom-classes-structs-and-types.md#IPackedAuto) interface, which will automatically handle the reading and writing of the data to the network. If this is not your style, take a look at the [IPacked](..\guides\networking-custom-classes-structs-and-types.md#IPacked) and [IPackedSimple](..\guides\networking-custom-classes-structs-and-types.md#IPackedSimple) interfaces.
+To get our chat message to the **Server**, we need to first create a struct to hold our data. As previously mentioned, this struct will hold a `name`, and a `message`. This struct will need to implement the [IPackedAuto](../guides/networking-custom-classes-structs-and-types.md#IPackedAuto) interface, which will automatically handle the reading and writing of the data to the network. If this is not your style, take a look at the [IPacked](../guides/networking-custom-classes-structs-and-types.md#IPacked) and [IPackedSimple](../guides/networking-custom-classes-structs-and-types.md#IPackedSimple) interfaces.
 
 The final struct is as follows:
 ```csharp


### PR DESCRIPTION
Replace `\` in markdown links to `/` as gitbook does not like backslashes